### PR TITLE
VS-Code Guide and macOS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # da156a
 The course website for: Introduktion till webbutveckling
+
+## Get started
+1. Clone the repository
+2. Install php
+3. Run `php -S localhost:8000` in the root of the project

--- a/exercises/1/index.php
+++ b/exercises/1/index.php
@@ -33,15 +33,15 @@
     <li>
         <p>Ett bra textredigeringsprogram. Med &#8220;bra&#8221; menas framförallt att programmet stödjer <a href="http://en.wikipedia.org/wiki/Syntax_highlighting">syntaxmarkering</a> för HTML - därutöver finns en mängd andra personliga preferenser.</p>
         <ul>
-            <li>För Windows så medföljer Notepad (Anteckningar), för Mac OS X medföljer TextEdit (Textredigerare). Dessa är inte jättebra.</li>
+            <li>För Windows så medföljer Notepad (Anteckningar), för macOS medföljer TextEdit (Textredigerare). Dessa är inte jättebra.</li>
             <li>På datorerna i skolan rekommenderas Visual Studio Code, Atom eller Brackets.</li>
             <li>För nedladdning till din egen dator finns otaliga alternativ. Några gratisvarianter är:
                 <ul>
-                    <li><a href="https://code.visualstudio.com/">VS Code</a> (Windows, OS X, Linux) - <strong>Rekommenderas</strong></li>
-                    <li><a href="http://atom.io/">Atom</a> (Windows, OS X, Linux)</li>
-                    <li><a href="http://brackets.io/">Brackets</a> (Windows, OS X, Linux)</li>
+                    <li><a href="https://code.visualstudio.com/">VS Code</a> (Windows, macOS, Linux) - <strong>Rekommenderas</strong></li>
+                    <li><a href="http://atom.io/">Atom</a> (Windows, macOS, Linux)</li>
+                    <li><a href="http://brackets.io/">Brackets</a> (Windows, macOS, Linux)</li>
                     <li><a href="http://notepad-plus-plus.org/">Notepad++</a> (Windows)</li>
-                    <li><a href="http://www.sublimetext.com/">Sublime Text</a> (Windows, OS X, Linux)</li>
+                    <li><a href="http://www.sublimetext.com/">Sublime Text</a> (Windows, macOS, Linux)</li>
                 </ul>
             </li>
         </ul>

--- a/resources.php
+++ b/resources.php
@@ -50,16 +50,16 @@ include "_header.php";
 
 		<h3>3. Verktyg</h3>
 		<p>
-			Webbutveckling är tacksamt, eftersom det inte kräver några speciella verktyg eller programvaror. I grunden behövs endast en enkel <a href="http://sv.wikipedia.org/wiki/Textredigerare">textredigerare</a>. Just enkla sådana följer med i princip alla operativsystem, som Notepad (Anteckningar) för Microsoft Windows, och TextEdit (Textredigerare) för Mac OS X.
+			Webbutveckling är tacksamt, eftersom det inte kräver några speciella verktyg eller programvaror. I grunden behövs endast en enkel <a href="http://sv.wikipedia.org/wiki/Textredigerare">textredigerare</a>. Just enkla sådana följer med i princip alla operativsystem, som Notepad (Anteckningar) för Microsoft Windows, och TextEdit (Textredigerare) för macOS.
 		</p>
 		<p>
 			Det blir dock roligare om man använder en textredigerare som &quot;förstår&quot; språken man använder. Minsta nivån att sträva efter är <a href="http://en.wikipedia.org/wiki/Syntax_highlighting">syntaxmarkering</a>, alltså en presentation av texten anpassat till att synliggöra språkets delar. Utöver detta finns många funktioner som kan vara hjälpsamma - men vad man prioriterar är väldigt personligt. Rekommendationen är att testa flera olika för att få en egen favorit.
 		</p>
 
 		<div class="col">
-			<h4>3.1. OS X</h4>
+			<h4>3.1. macOS</h4>
 			<ul>
-				<li><a href="https://code.visualstudio.com/">Visual Studio Code</a> (gratis)</li>
+				<li><a href="https://code.visualstudio.com/">Visual Studio Code</a> (gratis) - <strong>Rekommenderas</strong></li>
 				<li><a href="https://atom.io/">Atom</a> (gratis)</li>
 				<li><a href="http://brackets.io/">Brackets</a> (gratis)</li>
 			</ul>
@@ -68,7 +68,7 @@ include "_header.php";
 		<div class="col">
 			<h4>3.2. Windows</h4>
 			<ul>
-				<li><a href="https://code.visualstudio.com/">Visual Studio Code</a> (gratis)</li>
+				<li><a href="https://code.visualstudio.com/">Visual Studio Code</a> (gratis) - <strong>Rekommenderas</strong></li>
 				<li><a href="https://atom.io/">Atom</a> (gratis)</li>
 				<li><a href="http://brackets.io/">Brackets</a> (gratis)</li>
 				<li><a href="http://notepad-plus-plus.org">Notepad++</a> (gratis)</li>

--- a/resources.php
+++ b/resources.php
@@ -79,7 +79,12 @@ include "_header.php";
 			Verktyg där man grafiskt skapar en webbsida utan att själv skriva koden (&quot;what you see is what you get&quot;) rekommenderas inte - och är inte tillåtna i kursens uppgifter. En viktig poäng är att förstå bakomliggande tekniker och principer. Resultatet mycket bättre om man själv författar källkoden.
 		</p>
 
-		<h3>4. Malmö universitet-specifikt</h3>
+		<h3>4. Visual Studio Code</h3>
+		<p>
+			Visual Studio Code är en textredigerare från Microsoft, som är gratis och öppen källkod. Den är kraftfull och har många funktioner. Vi har därför satt ihop en <a href="/vs-code.php">liten guide för att komma igång</a>.
+		</p>
+
+		<h3>5. Malmö universitet-specifikt</h3>
 		<p>
 			För kursens studenter finns några specifika länkar, listade här av bekvämlighetsskäl:
 		</p>

--- a/vs-code.php
+++ b/vs-code.php
@@ -36,6 +36,7 @@ include "_header.php";
       <li>Ctrl + Shift + F (Cmd + Shift + F) - Sök i filer</li>
       <li>Ctrl + P (Cmd + P) - Öppna fil</li>
       <li>Ctrl + Shift + P (Cmd + Shift + P) - Öppna kommandorad</li>
+      <li>Ctrl + Shift + I (Cmd + Shift + I) - Formatera kod</li>
     </ul>
 
     <h3>Inställningar</h3>

--- a/vs-code.php
+++ b/vs-code.php
@@ -1,0 +1,81 @@
+<?php
+include "_header.php";
+?>
+
+<div class="row">
+	<div class="col-lg-8 create-submenu">
+		<h2>Visual Studio Code</h2>
+
+    <p>
+      Visual Studio Code är en textredigerare från Microsoft, som är gratis och öppen källkod. Den är kraftfull och har många funktioner, kanske lite för många i början. Vi har därför satt ihop en liten guide för att komma igång.
+    </p>
+
+    <h3>Installation</h3>
+    <p>
+      Gå till <a href="https://code.visualstudio.com/">Visual Studio Code</a> och ladda ner programmet. Installera det som vilket annat program som helst.
+    </p>
+
+    <h3>Grundläggande användning</h3>
+    <p>
+      När du öppnar programmet ser du en ganska tom skärm. I mitten finns en vit yta där du skriver din kod. Till vänster finns en meny med filer och mappar, och till höger finns en meny med verktyg och inställningar.
+    </p>
+    <p>
+      För att skapa en ny fil, tryck på <strong>File</strong> och sedan <strong>New file</strong>. Skriv din kod och spara filen genom att trycka på <strong>File</strong> och sedan <strong>Save</strong>, alternativt klicka Ctrl + C (för Windows) eller Cmd + C (för macOS).
+    </p>
+
+    <h3>Kortkommandon</h3>
+    <p>
+      Visual Studio Code har många kortkommandon för att snabbt navigera och skriva kod. Här är några exempel:
+    </p>
+    <ul>
+      <li>Ctrl + C (Cmd + C) - Kopiera</li>
+      <li>Ctrl + V (Cmd + V) - Klistra in</li>
+      <li>Ctrl + Z (Cmd + Z) - Ångra</li>
+      <li>Ctrl + S (Cmd + S) - Spara</li>
+      <li>Ctrl + F (Cmd + F) - Sök</li>
+      <li>Ctrl + Shift + F (Cmd + Shift + F) - Sök i filer</li>
+      <li>Ctrl + P (Cmd + P) - Öppna fil</li>
+      <li>Ctrl + Shift + P (Cmd + Shift + P) - Öppna kommandorad</li>
+    </ul>
+
+    <h3>Inställningar</h3>
+    <p>
+      Du kan ändra inställningar för Visual Studio Code genom att trycka på <strong>File</strong> och sedan <strong>Preferences</strong>. Här kan du ändra saker som färgschema, teckensnitt och kortkommandon. Vi skulle rekommendera att du kollar igenom inställningarna och ser vad som passar dig bäst, men undvik att ändra kortkommandon för dessa kan vara bra att lära sig.
+    </p>
+
+    <h4>Auto Save</h4>
+    <p>
+      En inställning som kan vara bra att ändra är <strong>Auto Save</strong>. När denna inställning är påslagen sparar Visual Studio Code automatiskt dina ändringar, så att du inte behöver trycka på Spara-knappen hela tiden. Du kan ändra inställningen genom att trycka på <strong>File</strong> och sedan <strong>Auto Save</strong>. Alternativt kan du trycka på Ctrl + Shift + P (Cmd + Shift + P) och skriva <strong>Auto Save</strong>.
+    </p>
+
+    <h4>Auto Close Tag</h4>
+    <p>
+      En annan inställning som kan vara bra att ändra är <strong>Auto Close Tag</strong>. När denna inställning är påslagen stänger Visual Studio Code automatiskt HTML-taggar när du skriver dem. Denna inställning är på som standard, men om du vill går den att stänga av. Du kan ändra inställningen genom att trycka på <strong>File</strong> och sedan <strong>Preferences</strong> och sedan <strong>Settings</strong>. Sök efter <strong>Auto Close Tag</strong> och bocka ur rutan.
+    </p>
+
+    <h3>Themes</h3>
+    <p>
+      Visual Studio Code har stöd för olika teman, som ändrar färgschemat på texten. Du kan ändra tema genom att trycka på <strong>File</strong> och sedan <strong>Preferences</strong> och sedan <strong>Color Theme</strong>. Välj ett tema som passar dig bäst.
+    </p>
+
+    <h3>Extensions</h3>
+    <p>
+      Visual Studio Code har stöd för extensions, som är tillägg som lägger till extra funktioner. Du kan installera extensions genom att trycka på <strong>View</strong> och sedan <strong>Extensions</strong>. Sök efter en extension och tryck på <strong>Install</strong> för att installera den.
+    </p>
+    <p>
+      Det kan vara bra att vänta lite med att installera extensions tills du har lärt dig grunderna i Visual Studio Code, eftersom de kan vara lite överväldigande i början, men det finns många bra extensions som kan underlätta ditt arbete. Här är listan på några extensions som vi rekommenderar:
+    </p>
+
+    <ul>
+      <li><a href="https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer">Live Server</a> - Startar en live-server som uppdateras automatiskt när du sparar</li>
+      <li><a href="https://marketplace.visualstudio.com/items?itemName=formulahendry.auto-rename-tag">Auto Rename Tag</a> - Uppdaterar motsvarande HTML-taggar när du ändrar en</li>
+      <li><a href="https://marketplace.visualstudio.com/items?itemName=CelianRiboulet.webvalidator">W3C Validation</a> - Validerar din HTML-kod mot W3C-standarden</li>
+    </ul>
+
+	</div>
+	<div class="col-lg-4 submenu-area"></div>
+</div>
+
+<?php
+include "_footer.php";
+?>


### PR DESCRIPTION
- Added a [VS-Code guide](https://da106a.ia-mau.se/vs-code.php) and linked it through the [resource page](https://da106a.ia-mau.se/resources.php). 
- Updated from Mac OS X to macOS. Mac OS X is the old name.
- Updated the README